### PR TITLE
Fix JSON schema generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Below is list of environment variables supported in the container image:
 
 ## Validate Rule Files
 
-The ReTaSC project includes a validator to ensure that rule files are correctly formatted and adhere to the expected schema `validator/schemas/rules_schema.yaml`.
+The ReTaSC project includes a validator to ensure that rule files are correctly
+formatted and adhere to the expected schema (see the section below).
 
 Example of validating a rule file with CLI:
 
@@ -59,10 +60,11 @@ retasc validate-rule example_rule.yaml
 
 ## Generate Rule Schema
 
-Example of generating JSON schema for rule files:
+Example of generating YAML and JSON schema for rule files:
 
 ```
-retasc generate-schema rule_schema.json
+retasc generate-schema rule_schema.yaml
+retasc generate-schema --json rule_schema.json
 ```
 
 ## Development

--- a/src/retasc/__main__.py
+++ b/src/retasc/__main__.py
@@ -31,9 +31,20 @@ def parse_args():
         "rule_file", type=str, help="Path to the rule file to validate"
     )
 
-    generate_parser = subparsers.add_parser("generate-schema", help="Generate a schema")
+    generate_parser = subparsers.add_parser(
+        "generate-schema", help="Generate YAML or JSON schema"
+    )
     generate_parser.add_argument(
-        "schema_file", type=str, help="Output schema file to generate"
+        "schema_file",
+        type=str,
+        nargs="?",
+        help="Output schema YAML or JSON file to generate (default is stdout)",
+    )
+    generate_parser.add_argument(
+        "-j",
+        "--json",
+        help="Generate JSON instead of the default YAML",
+        action="store_true",
     )
 
     return parser.parse_args()
@@ -52,5 +63,5 @@ def main():
             print(f"Validation failed: The rule file is invalid: {e}")
             sys.exit(1)
     elif args.command == "generate-schema":
-        generate_schema(args.schema_file)
+        generate_schema(args.schema_file, output_json=args.json)
     sys.exit(0)

--- a/src/retasc/validator/generate_schema.py
+++ b/src/retasc/validator/generate_schema.py
@@ -1,13 +1,22 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
+import json
+import sys
+from typing import TextIO
 
 import yaml
 
 from retasc.validator.models import Rule
 
 
-def generate_schema(output_path: str) -> None:
+def _generate_schema(file: TextIO, generator) -> None:
     schema = Rule.model_json_schema()
-    schema_yaml = yaml.dump(schema, sort_keys=False)
+    generator.dump(schema, file, indent=2, sort_keys=False)
 
-    with open(output_path, "w") as schema_file:
-        schema_file.write(schema_yaml)
+
+def generate_schema(output_path: str | None, *, output_json: bool) -> None:
+    generator = json if output_json else yaml
+    if output_path is None:
+        _generate_schema(sys.stdout, generator)
+    else:
+        with open(output_path, "w") as schema_file:
+            _generate_schema(schema_file, generator)

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -1,22 +1,38 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-import pytest
+import json
+
 import yaml
 
 from retasc.validator.generate_schema import generate_schema
 from retasc.validator.models import Rule
 
 
-def test_generate_schema(tmp_path):
-    schema_file = tmp_path / "rules_schema.yaml"
-    generate_schema(output_path=schema_file)
+def test_generate_json_schema(tmp_path):
+    schema_file = tmp_path / "rules_schema.json"
+    generate_schema(output_path=schema_file, output_json=True)
     with open(schema_file) as f:
-        schema = yaml.safe_load(f)
+        schema = json.load(f)
 
     expected_schema = Rule.model_json_schema()
     assert schema == expected_schema
 
 
-def test_generate_schema_exception():
-    with pytest.raises(Exception) as e:
-        generate_schema(output_path=".")
-    assert "Is a directory" in str(e.value)
+def test_generate_json_schema_to_stdout(tmp_path, capsys):
+    generate_schema(output_path=None, output_json=True)
+    stdout, stderr = capsys.readouterr()
+    schema = json.loads(stdout)
+
+    expected_schema = Rule.model_json_schema()
+    assert schema == expected_schema
+
+    assert stderr == ""
+
+
+def test_generate_yaml_schema(tmp_path):
+    schema_file = tmp_path / "rules_schema.yaml"
+    generate_schema(output_path=schema_file, output_json=False)
+    with open(schema_file) as f:
+        schema = yaml.safe_load(f)
+
+    expected_schema = Rule.model_json_schema()
+    assert schema == expected_schema

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,9 +2,15 @@
 import sys
 from unittest.mock import patch
 
-from pytest import mark, raises
+from pytest import fixture, mark, raises
 
 from retasc.__main__ import main
+
+
+@fixture
+def mock_generate_schema():
+    with patch("retasc.__main__.generate_schema") as mock:
+        yield mock
 
 
 def run_main(*args, expected_exit_code=None):
@@ -39,10 +45,26 @@ def test_dummy_run(capsys):
     assert stderr == ""
 
 
-@patch("retasc.__main__.generate_schema")
-def test_generate_schema(mock_generate_schema):
-    run_main("generate-schema", "output_schema.json", expected_exit_code=0)
-    mock_generate_schema.assert_called_once_with("output_schema.json")
+def test_generate_schema_yaml(mock_generate_schema):
+    run_main("generate-schema", "output_schema.yaml", expected_exit_code=0)
+    mock_generate_schema.assert_called_once_with(
+        "output_schema.yaml", output_json=False
+    )
+
+
+def test_generate_schema_yaml_to_stdout(mock_generate_schema):
+    run_main("generate-schema", expected_exit_code=0)
+    mock_generate_schema.assert_called_once_with(None, output_json=False)
+
+
+def test_generate_schema_json(mock_generate_schema):
+    run_main("generate-schema", "--json", "output_schema.json", expected_exit_code=0)
+    mock_generate_schema.assert_called_once_with("output_schema.json", output_json=True)
+
+
+def test_generate_schema_json_to_stdout(mock_generate_schema):
+    run_main("generate-schema", "--json", expected_exit_code=0)
+    mock_generate_schema.assert_called_once_with(None, output_json=True)
 
 
 def test_validate_rule_output(valid_rule_file, capsys):


### PR DESCRIPTION
Fix generating JSON schema (instead of less useful/common YAML schema).

Removes mentioning non-existing schema file. In future, there would be ideally a link to the schema file auto-generated by CI.