### PR TITLE
Add configuration for Renovate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,3 +73,9 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
+
+  # renovate.json validator
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 38.110.2
+    hooks:
+      - id: renovate-config-validator

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>konflux-ci/mintmaker//config/renovate/renovate.json",
+    "group:all",
+    "schedule:weekly"
+  ],
+  "dockerfile": {
+    "fileMatch": ["Containerfile"]
+  },
+  "packageRules": [
+    {
+      "description": "Patch and digest updates",
+      "matchUpdateTypes": [
+        "patch",
+        "digest"
+      ],
+      "groupName": "Auto merged updates",
+      "automerge": true,
+      "platformAutomerge": true
+    }
+  ],
+  "configMigration": true
+}


### PR DESCRIPTION
Renovate (red-hat-konflux bot) would update dependencies weekly (early Monday), group the updates and auto-merge if CI passes.

This should help avoiding the large amount of PRs from Konflux we have to merge.