### PR TITLE
Remove semgrep from tox

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -44,7 +44,6 @@ jobs:
       matrix:
         tox_env:
           - mypy
-          - semgrep
 
     runs-on: ubuntu-latest
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = mypy,semgrep,py3
+envlist = mypy,py3
 requires =
     poetry
 
@@ -18,15 +18,6 @@ commands =
         --cov-report=term \
         --cov-report=xml \
         --cov-report=html \
-        {posargs}
-
-[testenv:semgrep]
-deps =
-    semgrep
-commands =
-    semgrep scan --config=auto --error \
-        --exclude=docker-compose.yml \
-        --exclude=".*" \
         {posargs}
 
 [testenv:mypy]


### PR DESCRIPTION
Semgrep takes a long time to finish printing a lot of information messages that look like errors. Also, the licensing is not clear.