### PR TITLE
Avoid running GitLab CI on automated dependency updates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,11 @@ default:
   tags:
     - docker
 
+workflow:
+  rules:
+    # Avoid running CI on automated dependency updates (often partial)
+    - if: '$CI_COMMIT_BRANCH !~ /^konflux\/mintmaker/'
+
 # code-scanning-container
 # Requires SONAR_TOKEN variable in GitLab project.
 include:


### PR DESCRIPTION
Branch "origin/konflux/mintmaker/main/all-dependencies" seem to be often contain partial updates (e.g. lock file is not updated) without any open pull requests.