### PR TITLE
Skip releases with empty schedule

### DIFF
--- a/src/retasc/models/prerequisites/schedule.py
+++ b/src/retasc/models/prerequisites/schedule.py
@@ -26,10 +26,8 @@ class PrerequisiteSchedule(PrerequisiteBase):
         description="The name of the Product Pages schedule item."
     )
 
-    def _params(self, context) -> dict:
-        schedule = context.pp.release_schedules(context.release)
+    def _params(self, schedule: dict, context) -> dict:
         local_params = {"schedule": schedule}
-
         schedule_task = context.template.render(self.schedule_task, **local_params)
         task = schedule[schedule_task]
         local_params.update(
@@ -49,7 +47,12 @@ class PrerequisiteSchedule(PrerequisiteBase):
 
         Raises a HTTPError if the schedule task does not exist.
         """
-        local_params = self._params(context)
+        schedule = context.pp.release_schedules(context.release)
+        if schedule == {}:
+            context.report.set("pending_reason", "No schedule available yet")
+            return ReleaseRuleState.Pending
+
+        local_params = self._params(schedule, context)
         context.template.params.update(local_params)
         return ReleaseRuleState.Completed
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -428,6 +428,20 @@ def test_run_rule_schedule_target_date(target_date, is_draft, result, mock_pp, f
     assert report.data["rhel"]["rhel-10.0"][rule.name]["state"] == state
 
 
+def test_run_rule_schedule_missing(mock_pp, factory):
+    mock_pp.release_schedules.return_value = {}
+    rule = factory.new_rule(prerequisites=[PrerequisiteSchedule(schedule_task="TASK")])
+
+    report = call_run()
+    assert report.data["rhel"]["rhel-10.0"][rule.name] == {
+        "Schedule('TASK')": {
+            "state": "Pending",
+            "pending_reason": "No schedule available yet",
+        },
+        "state": "Pending",
+    }
+
+
 @mark.parametrize(
     ("condition_expr", "result"),
     (


### PR DESCRIPTION
ReTaSC should ignore releases in early Concept phases when the schedule is not yet available, because "schedule" prerequisites would error out on the missing schedule item.