### PR TITLE
Use nicer Jira field names from configuration

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -2,11 +2,5 @@ rules_path: examples/rules
 jira_template_path: examples/jira
 product_pages_url: https://pp.example.com
 jira_url: https://jira.example.com
-
-jira_fields:
-  description: description
-  labels: labels
-  project: project
-  summary: summary
-
+jira_fields: {}
 jira_label_prefix: retasc-id-

--- a/src/retasc/models/inputs/jira_issues.py
+++ b/src/retasc/models/inputs/jira_issues.py
@@ -19,8 +19,13 @@ class JiraIssues(InputBase):
     fields: list = Field(description="Jira issues fields to fetch")
 
     def values(self, context) -> Iterator[dict]:
-        issues = context.jira.search_issues(jql=self.jql, fields=self.fields)
+        jira_fields = [context.config.to_jira_field_name(f) for f in self.fields]
+        issues = context.jira.search_issues(jql=self.jql, fields=jira_fields)
         for issue in issues:
+            issue["fields"] = {
+                context.config.from_jira_field_name(f): v
+                for f, v in issue["fields"].items()
+            }
             yield {
                 "jira_issue": issue,
                 "jira_issues": issues,

--- a/src/retasc/models/prerequisites/jira_issue.py
+++ b/src/retasc/models/prerequisites/jira_issue.py
@@ -84,18 +84,7 @@ def _create_issue(
 
 
 def _template_to_issue_data(template_data: dict, context, template: str) -> dict:
-    unsupported_fields = [
-        name for name in template_data if name not in context.config.jira_fields
-    ]
-    if unsupported_fields:
-        field_list = to_comma_separated(unsupported_fields)
-        supported_fields = to_comma_separated(context.config.jira_fields)
-        raise RuntimeError(
-            f"Jira template {template!r} contains unsupported fields: {field_list}"
-            f"\nSupported fields: {supported_fields}"
-        )
-
-    fields = {context.config.jira_fields[k]: v for k, v in template_data.items()}
+    fields = {context.config.to_jira_field_name(k): v for k, v in template_data.items()}
 
     reserved_labels = {
         label
@@ -157,6 +146,9 @@ def _update_issue(
         )
         issue["fields"] = {"resolution": None, **fields}
 
+    issue["fields"] = {
+        context.config.from_jira_field_name(f): v for f, v in issue["fields"].items()
+    }
     _report_jira_issue(issue, jira_issue_id, context)
     return issue
 


### PR DESCRIPTION
Uses custom `jira_fields` config mapping to translate human-readable Jira field names in rules and templates to Jira issue data fields names so users never have to use/see field names like "customfield_12345678".