### PR TITLE
Allow setting phase range to get Product Pages releases

### DIFF
--- a/src/retasc/models/inputs/product_pages_releases.py
+++ b/src/retasc/models/inputs/product_pages_releases.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import re
 from collections.abc import Iterator
-from textwrap import dedent
 
 from pydantic import Field
 
 from retasc.models.inputs.base import InputBase
+from retasc.product_pages_api import Phase
 
 RE_VERSION = re.compile(r"^\w+-(?P<major>\d+)(?:[-.](?P<minor>\d+))?")
 
@@ -34,19 +34,13 @@ class ProductPagesReleases(InputBase):
     """
 
     product: str = Field(description="Product short name in Product Pages")
-    min_phase: str = Field(
-        default="Planning",
-        description=dedent("""
-            Minimum phase (inclusive) for filtering releases.
-            Available phases: Concept, Planning, Planning / Development / Testing, CI / CD, Development, Development / Testing, Testing, Exception, Launch, Maintenance, Unsupported
-        """),
+    min_phase: Phase = Field(
+        default=Phase.PLANNING,
+        description="Minimum phase (inclusive) for filtering releases",
     )
-    max_phase: str = Field(
-        default="Maintenance",
-        description=dedent("""
-            Maximum phase (inclusive) for filtering releases.
-            Available phases: Concept, Planning, Planning / Development / Testing, CI / CD, Development, Development / Testing, Testing, Exception, Launch, Maintenance, Unsupported
-        """),
+    max_phase: Phase = Field(
+        default=Phase.MAINTENANCE,
+        description="Maximum phase (inclusive) for filtering releases",
     )
 
     def values(self, context) -> Iterator[dict]:

--- a/src/retasc/product_pages_api.py
+++ b/src/retasc/product_pages_api.py
@@ -5,12 +5,29 @@ Production Pages API
 
 from dataclasses import dataclass
 from datetime import date
+from enum import Enum
 from functools import cache
 
 from opentelemetry import trace
 from requests import Session
 
 tracer = trace.get_tracer(__name__)
+
+
+class Phase(str, Enum):
+    """Available Product Pages release phases."""
+
+    CONCEPT = "Concept"
+    PLANNING = "Planning"
+    PLANNING_DEVELOPMENT_TESTING = "Planning / Development / Testing"
+    CI_CD = "CI / CD"
+    DEVELOPMENT = "Development"
+    DEVELOPMENT_TESTING = "Development / Testing"
+    TESTING = "Testing"
+    EXCEPTION = "Exception"
+    LAUNCH = "Launch"
+    MAINTENANCE = "Maintenance"
+    UNSUPPORTED = "Unsupported"
 
 
 @dataclass
@@ -35,8 +52,8 @@ class ProductPagesApi:
     def active_releases(
         self,
         product_shortname: str,
-        min_phase: str,
-        max_phase: str,
+        min_phase: Phase,
+        max_phase: Phase,
     ) -> list[str]:
         """
         Gets list of active release names within the specified phase range.
@@ -48,8 +65,8 @@ class ProductPagesApi:
         """
         opt = {
             "product__shortname": product_shortname,
-            "phase__gte": min_phase,
-            "phase__lte": max_phase,
+            "phase__gte": min_phase.value,
+            "phase__lte": max_phase.value,
             "fields": "shortname",
         }
         url = f"{self.api_url}/releases/"


### PR DESCRIPTION
AI agent prompt:

> Allow setting acceptable phase range (minimum, maximum) in ProductPagesReleases. This is by default "Concept" to "Unsupported" (in @product_pages_api.py), but this currently excludes "Concept" and "Unsupported" phases because it uses `phase__gt` (phase greater than) and `phase__lt` (phase less than) parameters. To include the phases, the `ProductPagesApi` class (in @product_pages_api.py) would need to use `phase__gte` (phase greater or equal than) and `phase__lte` (phase less or equal than) parameters. Available phases are:
> - Concept
> - Planning
> - Planning / Development / Testing
> - CI / CD
> - Development
> - Development / Testing
> - Testing
> - Exception
> - Launch
> - Maintenance
> - Unsupported

Fixed the default phases and reformat descriptions manually.

Followup AI agent prompt:

> Use an enum type (listing only available phases) for the phase parameters.

Assisted-by: Cursor, claude-4-sonnet