### PR TITLE
Fix sequence indentation in generated schemas

### DIFF
--- a/src/retasc/yaml.py
+++ b/src/retasc/yaml.py
@@ -12,7 +12,7 @@ def yaml_str_representer(dumper, data):
 
 @cache
 def yaml() -> YAML:
-    yaml = YAML(typ="safe")
+    yaml = YAML(typ="safe", pure=True)
     yaml.default_flow_style = False
     yaml.map_indent = 2
     yaml.sequence_indent = 4


### PR DESCRIPTION
According to the documentation `pure=True` must be used with `typ="safe"` for the indentation to work.

See: https://yaml.dev/doc/ruamel.yaml/detail/#Indentation_of_block_sequences