### PR TITLE
Tag image with '*-main' tags after running tests

### DIFF
--- a/.tekton/retasc-pull-request.yaml
+++ b/.tekton/retasc-pull-request.yaml
@@ -457,8 +457,15 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        - "pr{{pull_request_number}}"
       runAfter:
-      - build-image-index
+      - clair-scan
+      - clamav-scan
+      - rpms-signature-scan
+      - sast-shell-check
+      - sast-unicode-check
       taskRef:
         params:
         - name: name

--- a/.tekton/retasc-push.yaml
+++ b/.tekton/retasc-push.yaml
@@ -454,8 +454,18 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        # We need Renovate to update references to "*-main" tagged stable images.
+        # Renovate treats the text after the first hyphen as a type of platform/compatibility indicator.
+        # See: https://docs.renovatebot.com/modules/versioning/docker/
+        - "$(tasks.clone-repository.results.commit-timestamp)$(tasks.clone-repository.results.short-commit)-{{target_branch}}"
       runAfter:
-      - build-image-index
+      - clair-scan
+      - clamav-scan
+      - rpms-signature-scan
+      - sast-shell-check
+      - sast-unicode-check
       taskRef:
         params:
         - name: name


### PR DESCRIPTION
This would allow us to use Renovate to update the references to stable
images. The image tags can be ordered. The new tag format is:

    {commit-timestamp}{short-commit-sha}-main

The only problem would be if two commits have the same committed
date/time (the resolution is one second). In that case, it could happen
that the older commit tag gets applied later, because the push pipelines
can run in parallel.

Also, tags images built from Pull Requests with `pr{PR_ID}`.

JIRA: RHELWF-12927