### PR TITLE
Fix image tag for renovate

### DIFF
--- a/.tekton/retasc-push.yaml
+++ b/.tekton/retasc-push.yaml
@@ -459,7 +459,7 @@ spec:
         # We need Renovate to update references to "*-main" tagged stable images.
         # Renovate treats the text after the first hyphen as a type of platform/compatibility indicator.
         # See: https://docs.renovatebot.com/modules/versioning/docker/
-        - "$(tasks.clone-repository.results.commit-timestamp)$(tasks.clone-repository.results.short-commit)-{{target_branch}}"
+        - "$(tasks.clone-repository.results.commit-timestamp).$(tasks.clone-repository.results.short-commit)-{{target_branch}}"
       runAfter:
       - clair-scan
       - clamav-scan


### PR DESCRIPTION
Original code would construct tags like:
- 17516018504562435-main for older commit SHA 4562435
- 1751605590cb31524-main for newer commit SHA cb31524

Unfortunately, Renovate sorts by the number prefixes "17516018504562435" and "1751605590", and assumes the tag for the older commit is newer.

This changes the tag format to:

    {commit-timestamp}.{short-commit-sha}-stable