### PR TITLE
Fix image tag for renovate (2)

### DIFF
--- a/.tekton/retasc-push.yaml
+++ b/.tekton/retasc-push.yaml
@@ -459,7 +459,7 @@ spec:
         # We need Renovate to update references to "*-main" tagged stable images.
         # Renovate treats the text after the first hyphen as a type of platform/compatibility indicator.
         # See: https://docs.renovatebot.com/modules/versioning/docker/
-        - "$(tasks.clone-repository.results.commit-timestamp).$(tasks.clone-repository.results.short-commit)-{{target_branch}}"
+        - "$(tasks.clone-repository.results.commit-timestamp).$(tasks.clone-repository.results.short-commit)-stable"
       runAfter:
       - clair-scan
       - clamav-scan


### PR DESCRIPTION
This changes the tag format to:

    {commit-timestamp}.{short-commit-sha}-stable