### PR TITLE
Fix image versioning

### DIFF
--- a/.tekton/retasc-push.yaml
+++ b/.tekton/retasc-push.yaml
@@ -457,7 +457,7 @@ spec:
             # We need Renovate to update references to "*-main" tagged stable images.
             # Renovate treats the text after the first hyphen as a type of platform/compatibility indicator.
             # See: https://docs.renovatebot.com/modules/versioning/docker/
-        - "$(tasks.clone-repository.results.commit-timestamp).$(tasks.clone-repository.results.short-commit)-stable"
+        - "$(tasks.clone-repository.results.commit-timestamp)-stable"
       runAfter:
       - clair-scan
       - clamav-scan


### PR DESCRIPTION
Looks like renovate fails to update the tag format `{commit-timestamp}.{short-commit-sha}-stable`. Running renovate locally fails with an error:

    DEBUG: Could not determine new digest for update. (repository=local)

This change drops the commit SHA from the image tag - `{commit-timestamp}-stable`. Running renovate locally with this change shows the expected image tag update.

JIRA: RHELWF-13165