### PR TITLE
Allow defining simpler variables without evaluating the expression

### DIFF
--- a/src/retasc/models/inputs/variables.py
+++ b/src/retasc/models/inputs/variables.py
@@ -16,15 +16,12 @@ class Variables(InputBase):
     variables: dict[str, Any] = Field(
         description=dedent("""
             Template variables. Example:
-              { date: date('2027-06-01') }
+              { date: "2027-06-01") }
         """).strip()
     )
 
     def values(self, context) -> Iterator[dict]:
-        yield {
-            key: context.template.evaluate(value)
-            for key, value in self.variables.items()
-        }
+        yield self.variables
 
     def report_vars(self, values: dict) -> dict:
         return {"variables": {k: repr(v) for k, v in values.items()}}

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1469,15 +1469,15 @@ def test_run_rule_inherit_params(factory):
 
 
 def test_run_rule_fixed_date(factory):
-    input = Variables(variables={"date": "date('2020-01-01')"})
-    prereq = PrerequisiteTargetDate(target_date="date + 1|day")
+    input = Variables(variables={"target_date": "2020-01-01"})
+    prereq = PrerequisiteTargetDate(target_date="date(target_date) + 1|day")
     rule = factory.new_rule(inputs=[input], prerequisites=[prereq])
     report = call_run()
     assert report.data == {
         "inputs": [
             {
                 "type": "Variables",
-                "variables": {"date": "datetime.date(2020, 1, 1)"},
+                "variables": {"target_date": "'2020-01-01'"},
                 "rules": [
                     {
                         "rule": rule.name,
@@ -1485,7 +1485,7 @@ def test_run_rule_fixed_date(factory):
                             {
                                 "type": "TargetDate",
                                 "target_date": date(2020, 1, 2),
-                                "target_date_expr": "date + 1|day",
+                                "target_date_expr": "date(target_date) + 1|day",
                             }
                         ],
                         "state": "Completed",


### PR DESCRIPTION
This allows defining multi-line string variables more easily. Anything that need to be evaluated further can be done in "variable" prerequisites.

JIRA: RHELWF-12918