### PR TITLE
Include rendered Jira comment text in output and report

### DIFF
--- a/src/retasc/models/prerequisites/jira_issue.py
+++ b/src/retasc/models/prerequisites/jira_issue.py
@@ -214,6 +214,7 @@ def _add_issue_comment(issue_key: str, comment_template: str, context) -> None:
 
     context.jira.add_comment(issue_key, comment)
     context.report.set("comment_status", "added")
+    context.report.set("comment", comment)
 
 
 def _get_single_issue_or_raise(issues: list[dict], label: str) -> dict:

--- a/tests/test_prerequisite_jira_issue_comment.py
+++ b/tests/test_prerequisite_jira_issue_comment.py
@@ -50,6 +50,7 @@ def test_comment_added_to_new_issue(mock_context):
     assert state == ReleaseRuleState.InProgress
     mock_context.jira.add_comment.assert_called_once_with("TEST-1", comment_text)
     assert mock_context.report.current_data.get("comment_status") == "added"
+    assert mock_context.report.current_data.get("comment") == comment_text
 
 
 def test_comment_templated(mock_context):
@@ -88,6 +89,7 @@ def test_comment_templated(mock_context):
 
     assert state == ReleaseRuleState.InProgress
     mock_context.jira.add_comment.assert_called_once_with("TEST-2", expected_comment)
+    assert mock_context.report.current_data.get("comment") == expected_comment
 
 
 def test_comment_skipped_duplicate(mock_context):


### PR DESCRIPTION
Previously only "comment_status: added" was shown. Now the actual rendered comment is also included as "comment" in both the console output and the JSON report.

Assisted-by: Claude Opus 4.6